### PR TITLE
Feat: 배정된 공통 뷰 4개 구현

### DIFF
--- a/Projects/App/Sources/Common/CardItemView.swift
+++ b/Projects/App/Sources/Common/CardItemView.swift
@@ -1,0 +1,59 @@
+//
+//  CardItemView.swift
+//  gambler
+//
+//  Created by Hyo Myeong Ahn on 2/11/24.
+//  Copyright © 2024 gambler. All rights reserved.
+//
+
+import SwiftUI
+import Kingfisher
+
+struct CardItemView: View {
+    let game: Game
+    var playerString: String {
+        "인원 \(game.gameIntroduction.minPlayerCount) - \(game.gameIntroduction.maxPlayerCount)명"
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: .zero) {
+            if let url = URL(string: game.gameImage) {
+                KFImage(url)
+                    .resizable()
+                    .frame(width: 240, height: 300)
+                    .clipShape(RoundedRectangle(cornerRadius: 16.0))
+                    .scaledToFit()
+                    .overlay(alignment: .bottomLeading) {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(game.gameName)
+                                .font(.body1M)
+                                .foregroundStyle(Color.gray50)
+                            
+                            HStack(spacing: 8) {
+                                ReviewRatingCellView(review: game, textColor: .gray50)
+                                
+                                Text(playerString)
+                                    .foregroundStyle(Color.gray50)
+                                    .font(.caption1M)
+                            }
+                        }
+                        .padding(.bottom, 16)
+                        .padding(.leading, 16)
+                    }
+            } else {
+                RoundedRectangle(cornerRadius: 16.0)
+                    .frame(width: 240, height: 300)
+            }
+        }
+    }
+}
+
+#Preview {
+    CardItemView(game: Game(id: UUID().uuidString, gameName: "game",
+                            gameImage: "https://weefun.co.kr/shopimages/weefun/007009000461.jpg?1596805186",
+                            gameIntroduction: GameIntroduction(difficulty: 3.1, minPlayerCount: 2,
+                                                               maxPlayerCount: 4, playTime: 2,
+                                                               genre: .fantasy),
+                            descriptionImage: ["image"], gameLink: "link", createdDate: Date(),
+                            reviewCount: 5, reviewRatingAverage: 3.5))
+}

--- a/Projects/App/Sources/Common/GameCategoryCellView.swift
+++ b/Projects/App/Sources/Common/GameCategoryCellView.swift
@@ -10,11 +10,12 @@ import SwiftUI
 import Kingfisher
 
 struct GameCategoryCellView: View {
-    let game: Game
+    let imageUrl: String
+    let name: String
 
     var body: some View {
         VStack(spacing: 16) {
-            if let url = URL(string: game.gameImage) {
+            if let url = URL(string: imageUrl) {
                 KFImage(url)
                     .resizable()
                     .frame(width: 80, height: 80)
@@ -25,7 +26,7 @@ struct GameCategoryCellView: View {
                     .frame(width: 80, height: 80)
             }
             
-            Text(game.gameName)
+            Text(name)
                 .font(.body2M)
                 .foregroundStyle(Color.gray700)
         }
@@ -33,11 +34,5 @@ struct GameCategoryCellView: View {
 }
 
 #Preview {
-    GameCategoryCellView(game: Game(id: UUID().uuidString, gameName: "아임더보스",
-                                    gameImage: "https://weefun.co.kr/shopimages/weefun/007009000461.jpg?1596805186",
-                                    gameIntroduction: GameIntroduction(difficulty: 3.1, minPlayerCount: 2,
-                                                                       maxPlayerCount: 4, playTime: 2,
-                                                                       genre: .fantasy),
-                                    descriptionImage: ["image"], gameLink: "link", createdDate: Date(),
-                                    reviewCount: 5, reviewRatingAverage: 3.5))
+    GameCategoryCellView(imageUrl: "", name: "전략")
 }

--- a/Projects/App/Sources/Common/GameCategoryCellView.swift
+++ b/Projects/App/Sources/Common/GameCategoryCellView.swift
@@ -1,0 +1,43 @@
+//
+//  GameCategoryCellView.swift
+//  gambler
+//
+//  Created by Hyo Myeong Ahn on 2/11/24.
+//  Copyright © 2024 gambler. All rights reserved.
+//
+
+import SwiftUI
+import Kingfisher
+
+struct GameCategoryCellView: View {
+    let game: Game
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if let url = URL(string: game.gameImage) {
+                KFImage(url)
+                    .resizable()
+                    .frame(width: 80, height: 80)
+                    .scaledToFit()
+                    .clipShape(Circle())
+            } else {
+                Circle()
+                    .frame(width: 80, height: 80)
+            }
+            
+            Text(game.gameName)
+                .font(.body2M)
+                .foregroundStyle(Color.gray700)
+        }
+    }
+}
+
+#Preview {
+    GameCategoryCellView(game: Game(id: UUID().uuidString, gameName: "아임더보스",
+                                    gameImage: "https://weefun.co.kr/shopimages/weefun/007009000461.jpg?1596805186",
+                                    gameIntroduction: GameIntroduction(difficulty: 3.1, minPlayerCount: 2,
+                                                                       maxPlayerCount: 4, playTime: 2,
+                                                                       genre: .fantasy),
+                                    descriptionImage: ["image"], gameLink: "link", createdDate: Date(),
+                                    reviewCount: 5, reviewRatingAverage: 3.5))
+}

--- a/Projects/App/Sources/Common/GameGridItemView.swift
+++ b/Projects/App/Sources/Common/GameGridItemView.swift
@@ -1,0 +1,68 @@
+//
+//  GameGridItemView.swift
+//  gambler
+//
+//  Created by Hyo Myeong Ahn on 2/11/24.
+//  Copyright © 2024 gambler. All rights reserved.
+//
+
+import SwiftUI
+import Kingfisher
+
+struct GameGridItemView: View {
+    let game: Game
+    let likeGameIdArray: [String]
+    
+    var playerString: String {
+        "인원 \(game.gameIntroduction.minPlayerCount) - \(game.gameIntroduction.maxPlayerCount)명"
+    }
+    
+    var isLike: Bool {
+        likeGameIdArray.contains { id in
+            id == game.id
+        }
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let url = URL(string: game.gameImage) {
+                KFImage(url)
+                    .resizable()
+                    .frame(width: 155, height: 155)
+                    .clipShape(RoundedRectangle(cornerRadius: 8.0))
+                    .scaledToFit()
+                    .padding(.bottom, 8)
+                    .overlay(alignment: .topTrailing) {
+                        HeartCellView(isLike: isLike)
+                        .padding(8)
+                    }
+            } else {
+                RoundedRectangle(cornerRadius: 8.0)
+                    .frame(width: 155, height: 155)
+                    .padding(.bottom, 8)
+            }
+            
+            Text(game.gameName)
+                .font(.body1M)
+                .foregroundStyle(Color.gray700)
+            
+            HStack(spacing: 8) {
+                ReviewRatingCellView(review: game)
+                
+                Text(playerString)
+                    .foregroundStyle(Color.gray400)
+                    .font(.caption1M)
+            }
+        }
+    }
+}
+
+#Preview {
+    GameGridItemView(game: Game(id: UUID().uuidString, gameName: "game",
+                                gameImage: "https://weefun.co.kr/shopimages/weefun/007009000461.jpg?1596805186",
+                            gameIntroduction: GameIntroduction(difficulty: 3.1, minPlayerCount: 2,
+                                                               maxPlayerCount: 4, playTime: 2,
+                                                               genre: .fantasy),
+                            descriptionImage: ["image"], gameLink: "link", createdDate: Date(),
+                                reviewCount: 5, reviewRatingAverage: 3.5), likeGameIdArray: [])
+}

--- a/Projects/App/Sources/Common/HeartCellView.swift
+++ b/Projects/App/Sources/Common/HeartCellView.swift
@@ -1,0 +1,35 @@
+//
+//  HeartCellView.swift
+//  gambler
+//
+//  Created by Hyo Myeong Ahn on 2/13/24.
+//  Copyright © 2024 gambler. All rights reserved.
+//
+
+import SwiftUI
+
+struct HeartCellView: View {
+    let isLike: Bool
+
+    var body: some View {
+        VStack {
+            if isLike {
+                GamblerAsset.heartRed.swiftUIImage
+                    .resizable()
+                    .renderingMode(.template)
+                    .frame(width: 24, height: 24)
+                    .foregroundStyle(Color.primaryDefault)
+            } else {
+                GamblerAsset.heartgray.swiftUIImage
+                    .resizable()
+                    .renderingMode(.template)
+                    .frame(width: 24, height: 24)
+                    .foregroundStyle(Color.gray300)
+            }
+        }
+    }
+}
+
+#Preview {
+    HeartCellView(isLike: true)
+}

--- a/Projects/App/Sources/Common/ReviewRatingCellView.swift
+++ b/Projects/App/Sources/Common/ReviewRatingCellView.swift
@@ -1,0 +1,40 @@
+//
+//  ReviewRatingCellView.swift
+//  gambler
+//
+//  Created by Hyo Myeong Ahn on 2/13/24.
+//  Copyright © 2024 gambler. All rights reserved.
+//
+
+import SwiftUI
+
+struct ReviewRatingCellView: View {
+    let review: AvailableAggregateReview
+    var textColor: Color = .primaryDefault
+    
+    var body: some View {
+        HStack(spacing: 4) {
+            Group {
+                GamblerAsset.star.swiftUIImage
+                    .resizable()
+                    .renderingMode(.template)
+                    .frame(width: 18, height: 18)
+                
+                Text(String(format: "%.1f", review.reviewRatingAverage))
+                    .foregroundStyle(textColor)
+            }
+            .foregroundStyle(Color.primaryDefault)
+        }
+        .font(.caption1M)
+    }
+}
+
+#Preview {
+    ReviewRatingCellView(review: Game(id: UUID().uuidString, gameName: "game",
+                                      gameImage: "https://weefun.co.kr/shopimages/weefun/007009000461.jpg?1596805186",
+                                  gameIntroduction: GameIntroduction(difficulty: 3.1, minPlayerCount: 2,
+                                                                     maxPlayerCount: 4, playTime: 2,
+                                                                     genre: .fantasy),
+                                  descriptionImage: ["image"], gameLink: "link", createdDate: Date(),
+                                      reviewCount: 5, reviewRatingAverage: 3.5))
+}

--- a/Projects/App/Sources/Common/ShopListCellView.swift
+++ b/Projects/App/Sources/Common/ShopListCellView.swift
@@ -28,6 +28,9 @@ struct ShopListCellView: View {
                         .frame(width: 100, height: 100)
                         .clipShape(RoundedRectangle(cornerRadius: 8.0))
                         .scaledToFit()
+                } else {
+                    RoundedRectangle(cornerRadius: 8.0)
+                        .frame(width: 100, height: 100)
                 }
                 
                 VStack(alignment: .leading, spacing: 8) {
@@ -41,22 +44,13 @@ struct ShopListCellView: View {
                         HeartCellView(isLike: isLike)
                     }
 
-                    HStack(spacing: 4) {
-                        Group {
-                            GamblerAsset.star.swiftUIImage
-                                .resizable()
-                                .renderingMode(.template)
-                                .frame(width: 18, height: 18)
-                            
-                            Text(String(format: "%.1f", shop.reviewRatingAverage))
-                                .padding(.trailing, 4)
-                        }
-                        .font(.caption1M)
-                        .foregroundStyle(Color.primaryDefault)
-                    }
+                    ReviewRatingCellView(review: shop)
+                    
+                    Spacer()
                 }
                 .foregroundStyle(.black)
             }
+            .frame(height: 100)
         }
     }
 }

--- a/Projects/App/Sources/Common/ShopListCellView.swift
+++ b/Projects/App/Sources/Common/ShopListCellView.swift
@@ -1,0 +1,72 @@
+//
+//  ShopListCellView.swift
+//  gambler
+//
+//  Created by Hyo Myeong Ahn on 2/11/24.
+//  Copyright © 2024 gambler. All rights reserved.
+//
+
+import SwiftUI
+import Kingfisher
+
+struct ShopListCellView: View {
+    let shop: Shop
+    let likeShopIdArray: [String]
+    
+    var isLike: Bool {
+        likeShopIdArray.contains { id in
+            id == shop.id
+        }
+    }
+    
+    var body: some View {
+        VStack {
+            HStack(spacing: 16) {
+                if let url = URL(string: shop.shopImage) {
+                    KFImage(url)
+                        .resizable()
+                        .frame(width: 100, height: 100)
+                        .clipShape(RoundedRectangle(cornerRadius: 8.0))
+                        .scaledToFit()
+                }
+                
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("\(shop.shopName)")
+                            .font(.body1M)
+                            .foregroundStyle(Color.gray700)
+                        
+                        Spacer()
+                        
+                        HeartCellView(isLike: isLike)
+                    }
+
+                    HStack(spacing: 4) {
+                        Group {
+                            GamblerAsset.star.swiftUIImage
+                                .resizable()
+                                .renderingMode(.template)
+                                .frame(width: 18, height: 18)
+                            
+                            Text(String(format: "%.1f", shop.reviewRatingAverage))
+                                .padding(.trailing, 4)
+                        }
+                        .font(.caption1M)
+                        .foregroundStyle(Color.primaryDefault)
+                    }
+                }
+                .foregroundStyle(.black)
+            }
+        }
+    }
+}
+
+#Preview {
+    ShopListCellView(shop: Shop(id: UUID().uuidString, shopName: "레드버튼 강남점", shopAddress: "address",
+                            shopImage: "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20171201_108%2F1512073471785j1m5s_JPEG%2F201605__DSC0645.jpg",
+                            location: GeoPoint(latitude: 120.1, longitude: 140),
+                            shopPhoneNumber: "010-5555", menu: ["커피": 1000],
+                            openingHour: "10시", amenity: ["주차"], shopDetailImage: ["detailImage"],
+                            createdDate: Date(), reviewCount: 3,
+                                reviewRatingAverage: 3.5), likeShopIdArray: [])
+}

--- a/Projects/App/Sources/Model/Game.swift
+++ b/Projects/App/Sources/Model/Game.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Game: AvailableFirebase, Hashable {
+struct Game: AvailableFirebase, AvailableAggregateReview, Hashable {
     static func == (lhs: Game, rhs: Game) -> Bool {
         lhs.id == rhs.id
     }


### PR DESCRIPTION
[변경점] #18 

- 공통 뷰 구현했습니다.
  - GameCategoryCellView 구현
  - GameGridItemView 구현
  - ShopListCellView 구현
  - CardItemView 구현

- 찜하기 버튼인 하트와 별점 뷰 분리해서 구현했습니다.
  - HeartCellView
    - 터치 이벤트는 유저데이터 어떻게 처리할지 아직 안 정해져서 구현하지 않았습니다.
  - ReviewRatingCellView
    - Game 과 Shop 모두 이용 가능하게 만들기 위해 Game Model 에 AvailableAggregateReview 프로토콜 연결했습니다.

- ShopListCellView UI
  - Figma 에는 매장 소개글이 한 줄 들어가는데, 회의에서 소개글 데이터는 빼기로 했고, 디자인 분과 소통한 결과 우선 제목과 별점만 나오도록 구현했습니다.

To Reviewer

- 유저가 해당 매장이나 게임이 좋아요 상태인지 확인하기 위해  likeGameIdArray: [String] 값을 뷰에서 받도록 만들었습니다. 이런 방향의 구현이 맞는지 검토 부탁드립니다.