### PR TITLE
Feat: HomeView 게임 관련 목록 화면 구현, 더미GameDetailView 를 이용해 navigationPath 구현

### DIFF
--- a/Projects/App/Sources/Feature/Game/View/GameDetailView.swift
+++ b/Projects/App/Sources/Feature/Game/View/GameDetailView.swift
@@ -1,0 +1,35 @@
+//
+//  GameDetailView.swift
+//  gambler
+//
+//  Created by Hyo Myeong Ahn on 2/18/24.
+//  Copyright © 2024 gambler. All rights reserved.
+//
+
+import SwiftUI
+
+struct GameDetailView: View {
+    @Binding var path: NavigationPath
+    let game: Game
+    
+    var body: some View {
+        ScrollView {
+            Text(game.gameName)
+            
+            Spacer()
+            #warning("GameDetail 더미, NavigationPath 동작 보여주기 위해 추가함")
+            HomeGamesGridView(title: "연관게임", games: HomeViewModel().popularGames)
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Back to List") {
+                    path = NavigationPath()
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    GameDetailView(path: .constant(NavigationPath()), game: Game.dummyGame)
+}

--- a/Projects/App/Sources/Feature/Game/View/GameDetailView.swift
+++ b/Projects/App/Sources/Feature/Game/View/GameDetailView.swift
@@ -18,7 +18,7 @@ struct GameDetailView: View {
             
             Spacer()
             #warning("GameDetail 더미, NavigationPath 동작 보여주기 위해 추가함")
-            HomeGamesGridView(title: "연관게임", games: HomeViewModel().popularGames)
+            HomeGameGridView(title: "연관게임", games: HomeViewModel().popularGames)
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {

--- a/Projects/App/Sources/Feature/Home/View/HomeGameCardHScrollView.swift
+++ b/Projects/App/Sources/Feature/Home/View/HomeGameCardHScrollView.swift
@@ -1,0 +1,47 @@
+//
+//  HomeGameCardHScrollView.swift
+//  gambler
+//
+//  Created by Hyo Myeong Ahn on 2/18/24.
+//  Copyright © 2024 gambler. All rights reserved.
+//
+
+import SwiftUI
+
+struct HomeGameCardHScrollView: View {
+    let title: String
+    var games: [Game]
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            // TODO: SectionHeaderView 에서 패딩 제외해도 되는지 물어보고 사용하기
+            HStack {
+                Text(title)
+                    .font(.subHead1B)
+                    .foregroundStyle(Color.gray700)
+                Spacer()
+                GamblerAsset.arrowRight.swiftUIImage
+                    .resizable()
+                    .renderingMode(.template)
+                    .frame(width: 24, height: 24)
+                    .foregroundStyle(Color.gray400)
+            }
+            .padding(.trailing, 24)
+            
+            ScrollView(.horizontal) {
+                HStack(spacing: 16) {
+                    ForEach(games) { game in
+                        NavigationLink(value: game) {
+                            CardItemView(game: game)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.leading, 24)
+    }
+}
+
+#Preview {
+    HomeGameCardHScrollView(title: "흥미진진 신규게임", games: HomeViewModel().newGames)
+}

--- a/Projects/App/Sources/Feature/Home/View/HomeGameCategoryHScrollView.swift
+++ b/Projects/App/Sources/Feature/Home/View/HomeGameCategoryHScrollView.swift
@@ -1,0 +1,47 @@
+//
+//  HomeGameCategoryHScrollView.swift
+//  gambler
+//
+//  Created by Hyo Myeong Ahn on 2/18/24.
+//  Copyright © 2024 gambler. All rights reserved.
+//
+
+import SwiftUI
+
+struct HomeGameCategoryHScrollView: View {
+    let title: String
+    var categoryNames: [String]
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            // TODO: SectionHeaderView 에서 패딩 제외해도 되는지 물어보고 사용하기
+            HStack {
+                Text(title)
+                    .font(.subHead1B)
+                    .foregroundStyle(Color.gray700)
+                Spacer()
+                GamblerAsset.arrowRight.swiftUIImage
+                    .resizable()
+                    .renderingMode(.template)
+                    .frame(width: 24, height: 24)
+                    .foregroundStyle(Color.gray400)
+            }
+            .padding(.trailing, 24)
+            
+            ScrollView(.horizontal) {
+                HStack(spacing: 16) {
+                    ForEach(categoryNames, id: \.self) { categotyName in
+                        GameCategoryCellView(imageUrl: "", name: categotyName)
+                    }
+                }
+            }
+        }
+        .padding(.leading, 24)
+        .padding(.vertical, 32)
+        .background(Color.gray50)
+    }
+}
+
+#Preview {
+    HomeGameCategoryHScrollView(title: "종류별 Best", categoryNames: ["마피아", "블러핑"])
+}

--- a/Projects/App/Sources/Feature/Home/View/HomeGameGridView.swift
+++ b/Projects/App/Sources/Feature/Home/View/HomeGameGridView.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-struct HomeGamesGridView: View {
+struct HomeGameGridView: View {
     let title: String
     let games: [Game]
     let columns: [GridItem] = Array(repeating: .init(.fixed(155), spacing: 17, alignment: .leading), count: 2)
@@ -41,5 +41,5 @@ struct HomeGamesGridView: View {
 }
 
 #Preview {
-    HomeGamesGridView(title: "인기 게임", games: HomeViewModel().popularGames)
+    HomeGameGridView(title: "인기 게임", games: HomeViewModel().popularGames)
 }

--- a/Projects/App/Sources/Feature/Home/View/HomeGamesGridView.swift
+++ b/Projects/App/Sources/Feature/Home/View/HomeGamesGridView.swift
@@ -1,0 +1,45 @@
+//
+//  HomeGamesGridView.swift
+//  gambler
+//
+//  Created by Hyo Myeong Ahn on 2/18/24.
+//  Copyright © 2024 gambler. All rights reserved.
+//
+
+import SwiftUI
+
+struct HomeGamesGridView: View {
+    let title: String
+    let games: [Game]
+    let columns: [GridItem] = Array(repeating: .init(.fixed(155), spacing: 17, alignment: .leading), count: 2)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            // TODO: SectionHeaderView 에서 패딩 제외해도 되는지 물어보고 사용하기
+            HStack {
+                Text(title)
+                    .font(.subHead1B)
+                    .foregroundStyle(Color.gray700)
+                Spacer()
+                GamblerAsset.arrowRight.swiftUIImage
+                    .resizable()
+                    .renderingMode(.template)
+                    .frame(width: 24, height: 24)
+                    .foregroundStyle(Color.gray400)
+            }
+            
+            LazyVGrid(columns: columns, spacing: 24, content: {
+                ForEach(games) { game in
+                    NavigationLink(value: game) {
+                        GameGridItemView(game: game, likeGameIdArray: [])
+                    }
+                }
+            })
+        }
+        .padding(.horizontal, 24)
+    }
+}
+
+#Preview {
+    HomeGamesGridView(title: "인기 게임", games: HomeViewModel().popularGames)
+}

--- a/Projects/App/Sources/Feature/Home/View/HomeView.swift
+++ b/Projects/App/Sources/Feature/Home/View/HomeView.swift
@@ -16,7 +16,7 @@ struct HomeView: View {
         NavigationStack(path: $path) {
             ScrollView {
                 VStack(alignment: .leading, spacing: 32) {
-                    HomeGamesGridView(title: "채영님이 좋아하실 인기게임", games: homeViewModel.popularGames)
+                    HomeGameGridView(title: "채영님이 좋아하실 인기게임", games: homeViewModel.popularGames)
                     BorderView()
                     HomeShopListView(title: "인기 매장", shops: homeViewModel.popularShops)
                     BorderView()

--- a/Projects/App/Sources/Feature/Home/View/HomeView.swift
+++ b/Projects/App/Sources/Feature/Home/View/HomeView.swift
@@ -16,12 +16,19 @@ struct HomeView: View {
         NavigationStack(path: $path) {
             ScrollView {
                 VStack(alignment: .leading, spacing: 32) {
+                    HomeGamesGridView(title: "채영님이 좋아하실 인기게임", games: homeViewModel.popularGames)
+                    BorderView()
                     HomeShopListView(title: "인기 매장", shops: homeViewModel.popularShops)
                     BorderView()
+                    HomeGameCardHScrollView(title: "흥미진진 신규게임", games: homeViewModel.newGames)
+                    HomeGameCategoryHScrollView(title: "종류별 Best", categoryNames: ["마피아","블러핑","가족게임","전략"])
                     HomeShopListView(title: "신규 매장", shops: homeViewModel.newShops)
                 }
                 .navigationDestination(for: Shop.self) { shop in
                     ShopDetailView(shop: shop)
+                }
+                .navigationDestination(for: Game.self) { game in
+                    GameDetailView(path: $path, game: game)
                 }
             }
         }

--- a/Projects/App/Sources/Feature/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/App/Sources/Feature/Home/ViewModel/HomeViewModel.swift
@@ -20,7 +20,7 @@ final class HomeViewModel: ObservableObject {
 
     func generateDummyData() {
         let gameImageUrl: String =
-        "https://boardm.co.kr/upload/product/img4/img_largeupfilenm_1689313043_0.jpg?t=1682590618"
+        "https://weefun.co.kr/shopimages/weefun/007009000461.jpg?1596805186"
         let shopImageUrl: String =
         "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20201122_151%2F1606046564169SzUUi_JPEG%2FrkjG5CgJbjULKNT0NaPHKoHl.jpg"
         for num in 1...3 {


### PR DESCRIPTION
[변경점] #32 

- HomeGameGridView : 인기게임 그리드 뷰 구현
- HomeGameCardHScrollView : 신규게임 횡스크롤 뷰 구현
- HomeGameCategoryHScrollView : 게임 카테고리 횡스크롤 뷰 구현
- HomeView : 위에 추가한 게임 관련 3개 뷰 추가
- GameDetailView : navigationLink 타고 들어갈 더미 detailView 생성
- HomeViewModel : 더미 게임 이미지 변경

질문사항
- 공통 뷰인 SectionHeaderView 에서 4방향 패딩되어 있어서 사용하기가 불편하여 padding() 지워도 되는지 궁금합니다.
- 게임 카테고리 데이터 관리를 어떻게 할지 안정해져서 현재는 문자열을 임의로 추가한 상태입니다. 회의에서 정했으면 합니다.

To Reviewer
- 게임 그리드 뷰의 경우 파일 이름이 겹칠 우려가 있어 파일이름 앞에 Home 을 붙여서 만들었습니다.
- 회의를 통해 공통으로 쓰일 수 있다면 코드수정 및 재배치할 예정입니다.
- 현재는 공통 뷰인 SectionHeaderView 사용 안하고 따로 구현한 상태입니다. padding 제거해도 되는지 의견을 듣고 다음 PR 에 반영하도록 하겠습니다.