### PR TITLE
찜하기 로직 연결, 로그인 필요할 때 로그인뷰로 이동하는 로직 구현

### DIFF
--- a/Projects/App/Sources/Common/GameGridItemView.swift
+++ b/Projects/App/Sources/Common/GameGridItemView.swift
@@ -11,16 +11,9 @@ import Kingfisher
 
 struct GameGridItemView: View {
     let game: Game
-    let likeGameIdArray: [String]
     
     private var playerString: String {
         "인원 \(game.gameIntroduction.minPlayerCount) - \(game.gameIntroduction.maxPlayerCount)명"
-    }
-    
-    private var isLike: Bool {
-        likeGameIdArray.contains { id in
-            id == game.id
-        }
     }
     
     var body: some View {
@@ -34,7 +27,7 @@ struct GameGridItemView: View {
                     .scaledToFit()
                     .padding(.bottom, 8)
                     .overlay(alignment: .topTrailing) {
-                        HeartCellView(isLike: isLike, postId: game.id, postType: AppConstants.PostType.game)
+                        HeartCellView(postId: game.id, postType: AppConstants.PostType.game)
                             .padding(8)
                     }
             } else {
@@ -62,5 +55,5 @@ struct GameGridItemView: View {
 }
 
 #Preview {
-    GameGridItemView(game: Game.dummyGame, likeGameIdArray: [])
+    GameGridItemView(game: Game.dummyGame)
 }

--- a/Projects/App/Sources/Common/GameListItemView.swift
+++ b/Projects/App/Sources/Common/GameListItemView.swift
@@ -9,17 +9,9 @@
 import SwiftUI
 import Kingfisher
 
-struct GameListItemView: View {
-    
+struct GameListItemView: View {    
     let game: Game
-    let likeGameIdArray: [String]
-    
-    private var isLike: Bool {
-        likeGameIdArray.contains { id in
-            id == game.id
-        }
-    }
-    
+
     var body: some View {
         VStack {
             HStack(alignment: .top, spacing: AppConstants.Padding.horizontal) {
@@ -49,7 +41,7 @@ struct GameListItemView: View {
                         
                         Spacer()
                         
-                        HeartCellView(isLike: isLike, postId: game.id, postType: AppConstants.PostType.game)
+                        HeartCellView(postId: game.id, postType: AppConstants.PostType.game)
                     }
 
                     ReviewRatingCellView(rating: game.reviewRatingAverage)
@@ -67,5 +59,5 @@ struct GameListItemView: View {
 }
 
 #Preview {
-    GameListItemView(game: Game.dummyGame, likeGameIdArray: [])
+    GameListItemView(game: Game.dummyGame)
 }

--- a/Projects/App/Sources/Common/HeartCellView.swift
+++ b/Projects/App/Sources/Common/HeartCellView.swift
@@ -11,11 +11,24 @@ import SwiftUI
 struct HeartCellView: View {
     @EnvironmentObject private var loginViewModel: LoginViewModel
     @EnvironmentObject private var appNavigationPath: AppNavigationPath
-    let isLike: Bool
     let postId: String
     let postType: AppConstants.PostType
     @State private var isLiked: Bool = false
-//    var onHeartTapped: () -> Void = {}
+    
+    private var getCurrentHeartState: Bool {
+        if let curUser = loginViewModel.currentUser {
+            if postType == .game {
+                if let likeGameArray = curUser.likeGameId {
+                    return likeGameArray.contains { $0 == postId }
+                }
+            } else if postType == .shop {
+                if let likeShopArray = curUser.likeShopId {
+                    return likeShopArray.contains { $0 == postId }
+                }
+            }
+        }
+        return false
+    }
     
     var body: some View {
         VStack {
@@ -34,7 +47,7 @@ struct HeartCellView: View {
             }
         }
         .onAppear {
-            isLiked = isLike
+            isLiked = getCurrentHeartState
         }
         .onTapGesture {
             isLiked.toggle()
@@ -44,10 +57,9 @@ struct HeartCellView: View {
     
     private func updateLikeList() {
         guard var curUser = loginViewModel.currentUser else {
-            appNavigationPath.homeViewPath.append("로그인")
+            appNavigationPath.isGoTologin = true
             return
         }
-        
         var userLikeDictionary: [AnyHashable: Any] = [:]
         var likeKey: String = ""
         var updatedLikeArray: [String] = []
@@ -71,9 +83,9 @@ struct HeartCellView: View {
         }
         
         if postType == .game {
-            curUser.likeGameId = updatedLikeArray
+            loginViewModel.currentUser?.likeGameId = updatedLikeArray
         } else {
-            curUser.likeShopId = updatedLikeArray
+            loginViewModel.currentUser?.likeShopId = updatedLikeArray
         }
         
         userLikeDictionary[likeKey] = updatedLikeArray
@@ -85,5 +97,5 @@ struct HeartCellView: View {
 }
 
 #Preview {
-    HeartCellView(isLike: true, postId: "", postType: AppConstants.PostType.game)
+    HeartCellView(postId: "", postType: AppConstants.PostType.game)
 }

--- a/Projects/App/Sources/Common/ShopListCellView.swift
+++ b/Projects/App/Sources/Common/ShopListCellView.swift
@@ -11,14 +11,7 @@ import Kingfisher
 
 struct ShopListCellView: View {
     let shop: Shop
-    let likeShopIdArray: [String]
-    
-    var isLike: Bool {
-        likeShopIdArray.contains { id in
-            id == shop.id
-        }
-    }
-    
+
     var body: some View {
         VStack {
             HStack(alignment: .top, spacing: 16) {
@@ -44,7 +37,7 @@ struct ShopListCellView: View {
                         }
                         Spacer()
                         
-                        HeartCellView(isLike: isLike, postId: shop.id, postType: AppConstants.PostType.shop)
+                        HeartCellView(postId: shop.id, postType: AppConstants.PostType.shop)
                     }
 
                     ReviewRatingCellView(rating: shop.reviewRatingAverage)
@@ -64,5 +57,5 @@ struct ShopListCellView: View {
 }
 
 #Preview {
-    ShopListCellView(shop: Shop.dummyShop, likeShopIdArray: [])
+    ShopListCellView(shop: Shop.dummyShop)
 }

--- a/Projects/App/Sources/Feature/Game/View/GameDetailReviewHScrollView.swift
+++ b/Projects/App/Sources/Feature/Game/View/GameDetailReviewHScrollView.swift
@@ -30,7 +30,7 @@ struct GameDetailReviewHScrollView: View {
             DetailSectionHeaderView(title: "리뷰",
                                     reviewInfo: "\(formattedReviewRatingAverage)(\(game.reviewCount))") {
                 guard loginViewModel.currentUser != nil else {
-                    appNavigationPath.homeViewPath.append("로그인")
+                    appNavigationPath.isGoTologin = true
                     return
                 }
                 isNavigation = true

--- a/Projects/App/Sources/Feature/Game/View/GameDetailView.swift
+++ b/Projects/App/Sources/Feature/Game/View/GameDetailView.swift
@@ -152,7 +152,7 @@ struct GameDetailView: View {
                 
                 ItemButtonView(image: GamblerAsset.review.swiftUIImage, buttonName: "리뷰") {
                     guard loginViewModel.currentUser != nil else {
-                        appNavigationPath.homeViewPath.append("로그인")
+                        appNavigationPath.isGoTologin = true
                         return
                     }
                     isWriteReviewButton = true
@@ -168,7 +168,7 @@ struct GameDetailView: View {
     
     private func updateLikeGameList() {
         guard var curUser = loginViewModel.currentUser else {
-            appNavigationPath.homeViewPath.append("로그인")
+            appNavigationPath.isGoTologin = true
             return
         }
         
@@ -185,7 +185,7 @@ struct GameDetailView: View {
             updatedLikeArray.removeAll { $0 == game.id }
         }
         
-        curUser.likeGameId = updatedLikeArray
+        loginViewModel.currentUser?.likeGameId = updatedLikeArray
         
         userLikeDictionary["likeGameId"] = updatedLikeArray
         

--- a/Projects/App/Sources/Feature/Game/View/GameListView.swift
+++ b/Projects/App/Sources/Feature/Game/View/GameListView.swift
@@ -11,18 +11,9 @@ import SwiftUI
 struct GameListView: View {
     @EnvironmentObject private var gameListViewModel: GameListViewModel
     @EnvironmentObject private var appNavigationPath: AppNavigationPath
-    @EnvironmentObject private var loginViewModel: LoginViewModel
     let title: String
     private let columns: [GridItem] = Array(repeating:
-            .init(.flexible(minimum: 124, maximum: 200),
-                  spacing: 17, alignment: .leading), count: 2)
-    
-    private var likeGameIdArray: [String] {
-        if let curUser = loginViewModel.currentUser, let likeGameArray = curUser.likeGameId {
-            return likeGameArray
-        }
-        return []
-    }
+            .init(.flexible(minimum: 124, maximum: 200), spacing: 17, alignment: .leading), count: 2)
     
     var body: some View {
         VStack(spacing: 12) {
@@ -34,7 +25,7 @@ struct GameListView: View {
                         LazyVGrid(columns: columns, spacing: 24, content: {
                             ForEach(gameListViewModel.games) { game in
                                 NavigationLink(value: game) {
-                                    GameGridItemView(game: game, likeGameIdArray: likeGameIdArray)
+                                    GameGridItemView(game: game)
                                 }
                             }
                         })
@@ -43,7 +34,7 @@ struct GameListView: View {
                         VStack(spacing: 24) {
                             ForEach(gameListViewModel.games) { game in
                                 NavigationLink(value: game) {
-                                    GameListItemView(game: game, likeGameIdArray: likeGameIdArray)
+                                    GameListItemView(game: game)
                                 }
                                 if game != gameListViewModel.games.last {
                                     Divider()
@@ -104,6 +95,5 @@ struct GameListView: View {
         GameListView(title: "인기 게임")
             .environmentObject(AppNavigationPath())
             .environmentObject(GameListViewModel())
-            .environmentObject(LoginViewModel())
     }
 }

--- a/Projects/App/Sources/Feature/Home/View/HomeGameGridView.swift
+++ b/Projects/App/Sources/Feature/Home/View/HomeGameGridView.swift
@@ -10,11 +10,11 @@ import SwiftUI
 
 struct HomeGameGridView: View {
     @EnvironmentObject private var appNavigationPath: AppNavigationPath
+    @EnvironmentObject private var loginViewModel: LoginViewModel
     let title: String
     let games: [Game]
-    let columns: [GridItem] = Array(repeating:
-            .init(.flexible(minimum: 124, maximum: 200),
-                  spacing: 17, alignment: .leading), count: 2)
+    private let columns: [GridItem] = Array(repeating:
+            .init(.flexible(minimum: 124, maximum: 200), spacing: 17, alignment: .leading), count: 2)
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
@@ -26,7 +26,7 @@ struct HomeGameGridView: View {
             LazyVGrid(columns: columns, spacing: 24, content: {
                 ForEach(games) { game in
                     NavigationLink(value: game) {
-                        GameGridItemView(game: game, likeGameIdArray: [])
+                        GameGridItemView(game: game)
                     }
                 }
             })

--- a/Projects/App/Sources/Feature/Home/View/HomeShopListView.swift
+++ b/Projects/App/Sources/Feature/Home/View/HomeShopListView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct HomeShopListView: View {
     @EnvironmentObject private var appNavigationPath: AppNavigationPath
+    @EnvironmentObject private var loginViewModel: LoginViewModel
     let title: String
     var shops: [Shop]
     
@@ -23,7 +24,7 @@ struct HomeShopListView: View {
                 
                 ForEach(shops) { shop in
                     NavigationLink(value: shop) {
-                        ShopListCellView(shop: shop, likeShopIdArray: [])
+                        ShopListCellView(shop: shop)
                     }
                     if shop != shops.last {
                         Divider()

--- a/Projects/App/Sources/Feature/Home/View/HomeView.swift
+++ b/Projects/App/Sources/Feature/Home/View/HomeView.swift
@@ -49,10 +49,11 @@ struct HomeView: View {
                         GameListView(title: title)
                     } else if title.contains("매장") {
                         ShopListView(title: title)
-                    } else if title == "로그인" {
-                        LoginView()
                     }
                 }
+                .navigationDestination(isPresented: $appNavigationPath.isGoTologin, destination: {
+                    LoginView()
+                })
                 .buttonStyle(HiddenClickAnimationButtonStyle())
             }
             .coordinateSpace(name: "HOMESCROLL")

--- a/Projects/App/Sources/Feature/Map/View/MapView.swift
+++ b/Projects/App/Sources/Feature/Map/View/MapView.swift
@@ -66,6 +66,9 @@ struct MapView: View {
             }
             .edgesIgnoringSafeArea(.top)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationDestination(isPresented: $appNavigationPath.isGoTologin, destination: {
+                LoginView()
+            })
         }
     }
     

--- a/Projects/App/Sources/Feature/Map/View/SubView/FloatingCellView.swift
+++ b/Projects/App/Sources/Feature/Map/View/SubView/FloatingCellView.swift
@@ -42,7 +42,7 @@ struct FloatingCellView: View {
                         
                         Spacer()
                         
-                        HeartCellView(isLike: isLike, postId: shop.id, postType: AppConstants.PostType.shop)
+                        HeartCellView(postId: shop.id, postType: AppConstants.PostType.shop)
                     }
                     
                     ReviewRatingCellView(rating: shop.reviewRatingAverage)

--- a/Projects/App/Sources/Feature/Map/View/SubView/MapSheetView.swift
+++ b/Projects/App/Sources/Feature/Map/View/SubView/MapSheetView.swift
@@ -24,7 +24,7 @@ struct MapSheetView: View {
                     VStack(spacing: 24) {
                         ForEach(mapViewModel.areaInShopList) { shop in
                             NavigationLink(value: shop) {
-                                ShopListCellView(shop: shop, likeShopIdArray: [])
+                                ShopListCellView(shop: shop)
                             }
                             if shop != mapViewModel.areaInShopList.last {
                                 Divider()

--- a/Projects/App/Sources/Feature/MyPage/View/MyLikesView.swift
+++ b/Projects/App/Sources/Feature/MyPage/View/MyLikesView.swift
@@ -43,7 +43,7 @@ struct MyLikesView: View {
                         .padding(.bottom, 0)
                     
                     ForEach(shops) { shop in
-                        ShopListCellView(shop: shop, likeShopIdArray: [])
+                        ShopListCellView(shop: shop)
                         
                         if shop != shops.last {
                             Divider()
@@ -73,7 +73,7 @@ struct MyLikesView: View {
                     
                     LazyVGrid(columns: columns, spacing: 24) {
                         ForEach(games) { game in
-                            GameGridItemView(game: game, likeGameIdArray: [])
+                            GameGridItemView(game: game)
                         }
                     }
                 }

--- a/Projects/App/Sources/Feature/Search/View/SearchGameListView.swift
+++ b/Projects/App/Sources/Feature/Search/View/SearchGameListView.swift
@@ -17,7 +17,7 @@ struct SearchGameListView: View {
     var body: some View {
         VStack {
             InfiniteList(gameViewModel) { game in
-                GameListItemView(game: game.object, likeGameIdArray: [])
+                GameListItemView(game: game.object)
                     .onTapGesture {
                         appNavigationPath.searchViewPath.append(game.object)
                     }
@@ -30,5 +30,3 @@ struct SearchGameListView: View {
         .modifier(BackButton())
     }
 }
-
-

--- a/Projects/App/Sources/Feature/Search/View/SearchMainView.swift
+++ b/Projects/App/Sources/Feature/Search/View/SearchMainView.swift
@@ -58,6 +58,9 @@ struct SearchMainView: View {
                 .navigationDestination(for: Game.self) { game in
                     GameDetailView(game: game)
                 }
+                .navigationDestination(isPresented: $appNavigationPath.isGoTologin, destination: {
+                    LoginView()
+                })
             }
         }
     }

--- a/Projects/App/Sources/Feature/Search/View/SearchResultView.swift
+++ b/Projects/App/Sources/Feature/Search/View/SearchResultView.swift
@@ -34,7 +34,7 @@ struct SearchResultView: View {
                     if shopHitsCount < 3 {
                         ForEach(0..<shopHitsCount, id: \.self) { index in
                             if let shop = shopHitsController.hits[index] {
-                                ShopListCellView(shop: shop.object, likeShopIdArray: [])
+                                ShopListCellView(shop: shop.object)
                                     .onTapGesture {
                                         appNavigationPath.searchViewPath.append(shop.object)
                                     }
@@ -43,7 +43,7 @@ struct SearchResultView: View {
                     } else {
                         ForEach(0..<3, id: \.self) { index in
                             if let shop = shopHitsController.hits[index] {
-                                ShopListCellView(shop: shop.object, likeShopIdArray: [])
+                                ShopListCellView(shop: shop.object)
                                     .onTapGesture {
                                         appNavigationPath.searchViewPath.append(shop.object)
                                     }
@@ -69,7 +69,7 @@ struct SearchResultView: View {
                     if gameHitsCount < 3 {
                         ForEach(0..<gameHitsCount, id: \.self) { index in
                             if let game = gameHitsController.hits[index] {
-                                GameListItemView(game: game.object, likeGameIdArray: [])
+                                GameListItemView(game: game.object)
                                     .onTapGesture {
                                         appNavigationPath.searchViewPath.append(game.object)
                                     }
@@ -78,7 +78,7 @@ struct SearchResultView: View {
                     } else {
                         ForEach(0..<3, id: \.self) { index in
                             if let game = gameHitsController.hits[index] {
-                                GameListItemView(game: game.object, likeGameIdArray: [])
+                                GameListItemView(game: game.object)
                                     .onTapGesture {
                                         appNavigationPath.searchViewPath.append(game.object)
                                     }

--- a/Projects/App/Sources/Feature/Search/View/SearchShopListView.swift
+++ b/Projects/App/Sources/Feature/Search/View/SearchShopListView.swift
@@ -17,7 +17,7 @@ struct SearchShopListView: View {
     var body: some View {
         VStack {
             InfiniteList(shopViewModel) { shop in
-                ShopListCellView(shop: shop.object, likeShopIdArray: [])
+                ShopListCellView(shop: shop.object)
                     .onTapGesture {
                         appNavigationPath.searchViewPath.append(shop.object)
                     }

--- a/Projects/App/Sources/Feature/Shop/View/ShopDetailInfoView.swift
+++ b/Projects/App/Sources/Feature/Shop/View/ShopDetailInfoView.swift
@@ -177,7 +177,7 @@ struct ShopDetailInfoView: View {
     
     private func updateLikeShopList() {
         guard var curUser = loginViewModel.currentUser else {
-            appNavigationPath.homeViewPath.append("로그인")
+            appNavigationPath.isGoTologin = true
             return
         }
         
@@ -194,7 +194,7 @@ struct ShopDetailInfoView: View {
             updatedLikeArray.removeAll { $0 == shop.id }
         }
         
-        curUser.likeShopId = updatedLikeArray
+        loginViewModel.currentUser?.likeShopId = updatedLikeArray
         
         userLikeDictionary["likeShopId"] = updatedLikeArray
         

--- a/Projects/App/Sources/Feature/Shop/View/ShopListView.swift
+++ b/Projects/App/Sources/Feature/Shop/View/ShopListView.swift
@@ -32,7 +32,7 @@ struct ShopListView: View {
                 VStack(spacing: 24) {
                     ForEach(shopListViewModel.shops) { shop in
                         NavigationLink(value: shop) {
-                            ShopListCellView(shop: shop, likeShopIdArray: [])
+                            ShopListCellView(shop: shop)
                         }
                         if shop != shopListViewModel.shops.last {
                             Divider()

--- a/Projects/App/Sources/Service/AppNavigationPath.swift
+++ b/Projects/App/Sources/Service/AppNavigationPath.swift
@@ -13,4 +13,7 @@ final class AppNavigationPath: ObservableObject {
     @Published var searchViewPath = NavigationPath()
     @Published var mapViewPath = NavigationPath()
     @Published var loginViewPath = NavigationPath()
+    
+    /// 로그인 필요할 때 LoginView 이동 navigationDestination 용 flag
+    @Published var isGoTologin: Bool = false
 }


### PR DESCRIPTION
변경점 #98 

# 변경사항

## 공통뷰
- HeartCellView 에 찜하기 관련 로직 구현했습니다.
- GameGridItemView,  GameListItemView, ShopListCellView
  - likeGameIdArray, likeShopIdArray 를 제거했습니다.
  - 이를 사용하던 여러 부분 코드 수정했습니다.

## 로그인 화면으로 이동
- AppNavigationPath 가 각 탭마다 각각 다른 변수를 사용하므로 isGoTologin:Bool 변수를 만들고 이를 통해 로그인뷰로 이동을 제어했습니다.
- NavigationStack 도 각 탭마다 나눠져 있으므로 각각 탭의 최상단 뷰에 .navigationDestination() 추가했습니다.
- MyPageView 는 필요없을 것 같아 추가하지 않았습니다.



# To Reviewer
- ShopDetailInfoView 에 찜하기는 ItemButtonSetView 공통뷰에 작업해야 할 것 같습니다. pr 올린 후 바로 작업 시작하겠습니다.