### PR TITLE
Fix/#105 game,home view,view model

### DIFF
--- a/Projects/App/Sources/App/GamblerApp.swift
+++ b/Projects/App/Sources/App/GamblerApp.swift
@@ -47,6 +47,7 @@ struct GamblerApp: App {
     @StateObject private var gameDetailViewModel = GameDetailViewModel()
     @StateObject private var shopListViewModel = ShopListViewModel()
     @StateObject private var reviewViewModel = ReviewViewModel()
+    @StateObject private var profileEditViewModel = ProfileEditViewModel()
     @StateObject private var tabSelection = TabSelection()
     
     var body: some Scene {
@@ -73,6 +74,7 @@ struct GamblerApp: App {
         .environmentObject(myPageViewModel)
         .environmentObject(loginViewModel)
         .environmentObject(reviewViewModel)
+        .environmentObject(profileEditViewModel)
         .environmentObject(tabSelection)
     }
     

--- a/Projects/App/Sources/Feature/Login/View/LoginView.swift
+++ b/Projects/App/Sources/Feature/Login/View/LoginView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import AuthenticationServices
 
 struct LoginView: View {
+    @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var loginViewModel: LoginViewModel
     @State private var isShowingRegistrationView: Bool = false
     
@@ -78,6 +79,11 @@ struct LoginView: View {
         .onReceive(loginViewModel.$authState) { authState in
             if authState == .creatingAccount && loginViewModel.userSession != nil {
                 isShowingRegistrationView = true
+            }
+        }
+        .onChange(of: loginViewModel.authState) { _, newValue in
+            if newValue == .signedIn {
+                dismiss()
             }
         }
         .modifier(BackButton())

--- a/Projects/App/Sources/Feature/Login/ViewModel/LoginViewModel.swift
+++ b/Projects/App/Sources/Feature/Login/ViewModel/LoginViewModel.swift
@@ -43,6 +43,7 @@ final class LoginViewModel: ObservableObject {
                 print("User is nil")
                 self.authState = .signedOut
                 self.currentUser = nil
+                AuthService.shared.isLoading = false
                 return
             }
             

--- a/Projects/App/Sources/Feature/MyPage/View/CustomerServiceView.swift
+++ b/Projects/App/Sources/Feature/MyPage/View/CustomerServiceView.swift
@@ -77,7 +77,6 @@ struct CustomerServiceView: View {
                                                                   folder: .complain),
                                                          createdDate: Date()))
             myPageViewModel.toastCategory = .complain
-            myPageViewModel.isShowingToast = true
         }
         presentationMode.wrappedValue.dismiss()
         withAnimation(.easeIn(duration: 0.4)) {

--- a/Projects/App/Sources/Feature/MyPage/View/MyPageSignedOutView.swift
+++ b/Projects/App/Sources/Feature/MyPage/View/MyPageSignedOutView.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct MyPageSignedOutView: View {
     @EnvironmentObject private var loginViewModel: LoginViewModel
     @EnvironmentObject private var appNavigationPath: AppNavigationPath
-    @State private var isShowingloginView: Bool = false
     
     var body: some View {
         NavigationStack(path: $appNavigationPath.loginViewPath) {
@@ -22,13 +21,13 @@ struct MyPageSignedOutView: View {
 
                 CTAButton(disabled: .constant(false), title: "로그인 하러가기") {
                     Task {
-                        isShowingloginView.toggle()
+                        appNavigationPath.isGoTologin = true
                         await loginViewModel.logoutFromFirebaseAndSocial()
                     }
                 }
                 .frame(width: 180)
             }
-            .navigationDestination(isPresented: $isShowingloginView) {
+            .navigationDestination(isPresented: $appNavigationPath.isGoTologin) {
                 LoginView()
             }
         }

--- a/Projects/App/Sources/Service/AppleAuthService.swift
+++ b/Projects/App/Sources/Service/AppleAuthService.swift
@@ -147,6 +147,7 @@ extension AppleAuthService {
                         print(#fileID, #function, #line, "- tempUSer ")
                         dump(AuthService.shared.tempUser)
                     } catch {
+                        AuthService.shared.isLoading = false
                         print("Error authenticating: \(error.localizedDescription)")
                     }
                 }

--- a/Projects/App/Sources/Service/GoogleAuthService.swift
+++ b/Projects/App/Sources/Service/GoogleAuthService.swift
@@ -24,8 +24,8 @@ final class GoogleAuthSerVice {
             if let error {
                 print("GoogleSignInError: failed to sign in with Google, \(error))")
             }
-            AuthService.shared.isLoading = true
             guard let gidUser = user else { return }
+            AuthService.shared.isLoading = true
             Task {
                 do {
                     let result = try await GoogleAuthSerVice.shared.authenticateGoogle(gidUser)
@@ -41,6 +41,7 @@ final class GoogleAuthSerVice {
                                                              loginPlatform: .google)
                     }
                 } catch {
+                    AuthService.shared.isLoading = false
                     print("GoogleSignInError: failed to authenticate with Google, \(error))")
                 }
             }

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -38,7 +38,8 @@ public extension Project {
                 resources: resources,
                 entitlements: entitlements,
                 scripts: [.SwiftLintShell],
-                dependencies: dependencies
+                dependencies: dependencies,
+                environmentVariables: ["IDEPreferLogStreaming": .init(stringLiteral: "YES")]
             )
 
             let testTarget = Target(
@@ -49,7 +50,8 @@ public extension Project {
                 deploymentTarget: deploymentTarget,
                 infoPlist: .default,
                 sources: ["Tests/**"],
-                dependencies: [.target(name: name)]
+                dependencies: [.target(name: name)],
+                environmentVariables: ["IDEPreferLogStreaming": .init(stringLiteral: "YES")]
             )
 
             let schemes: [Scheme] = [.makeScheme(target: .debug, name: name)]


### PR DESCRIPTION
변경점 #108 

# 변경사항

## Tuist
- 앱 시작 시 Logging Error 해결 (참고 - #103)

## Login
- 구글 로그인 취소 시 커스텀 로딩이 계속 되는 문제 해결
- 리뷰 작성 등으로 인해 로그인을 했을 시 로그인 뷰에서 뷰가 유지되는 문제 해결 
  - (@licors - 로그인 시 dismiss 하도록 했는데, 홈뷰에서 네비게이션이 시작해서 게임 디테일 뷰나 리뷰 디테일뷰가 아닌 홈 뷰로 이동하게 됩니다..)

## CustomerService
- 이미지가 있으면 토스트 메시지 두 번 뜨는 문제 해결

## 앨범 권한
- picker 는 process 없이 돌아가므로 라이브러리 액세스를 요청할 필요가 없습니다. (아래 블로그는 WWDC를 요약한 내용인데 초반에 해당 내용이 나옵니다.!)
  - https://gyuios.tistory.com/201 

# To Reviewer
