### PR TITLE
홈,게임 관련 테스트플라이트 테스트에서 수정사항 구현

### DIFF
--- a/Projects/App/Sources/Common/SectionHeaderView.swift
+++ b/Projects/App/Sources/Common/SectionHeaderView.swift
@@ -19,6 +19,8 @@ struct SectionHeaderView: View {
             Text(title)
                 .font(.subHead1B)
                 .foregroundStyle(Color.gray700)
+                .lineLimit(1)
+                .truncationMode(.tail)
             if let count {
                 Text("\(count)개")
                     .font(.subHead1B)

--- a/Projects/App/Sources/Feature/EventBanner/View/EventBannerView.swift
+++ b/Projects/App/Sources/Feature/EventBanner/View/EventBannerView.swift
@@ -62,6 +62,7 @@ struct EventBannerView: View {
                                         .padding(.leading, 24)
                                         .offset(x: (offset > 0 ? offset / 2 : 0))
                                     }
+                                    .roundedCorner(16, corners: [.bottomLeft, .bottomRight])
                             }
                             .offset(x: (offset > 0 ? -offset / 2 : 0), y: (offset > 0 ? -offset : 0))
                             .onAppear {

--- a/Projects/App/Sources/Feature/Game/View/GameDetailInfoView.swift
+++ b/Projects/App/Sources/Feature/Game/View/GameDetailInfoView.swift
@@ -22,11 +22,12 @@ struct GameDetailInfoView: View {
             VStack(spacing: 24) {
                 VStack(alignment: .leading, spacing: 8) {
                     Text("게임 방법")
-                        .font(.body1B)
-                    // 색상 8A8A8A
+                        .font(.subHead1B)
+                        .padding(.bottom,8)
                     Text(splitTextByPeriod(text: game.descriptionContent))
-                        .font(.body2M)
+                        .font(.body1M)
                         .foregroundStyle(Color.gray500)
+                        .lineSpacing(8.0)
                 }
                 VStack(spacing: .zero) {
                     if let descriptionImageUrls = game.descriptionImage {

--- a/Projects/App/Sources/Feature/Game/View/GameDetailReviewHScrollView.swift
+++ b/Projects/App/Sources/Feature/Game/View/GameDetailReviewHScrollView.swift
@@ -35,7 +35,6 @@ struct GameDetailReviewHScrollView: View {
                 }
                 isNavigation = true
             }
-            .padding(.trailing, 24)
             .navigationDestination(isPresented: $isNavigation) {
                 ReviewDetailView(reviewableItem: game, targetName: game.gameName)
             }
@@ -48,6 +47,7 @@ struct GameDetailReviewHScrollView: View {
                         }
                     }
                 }
+                .scrollIndicators(.hidden)
             } else {
                 VStack {
                     Text("첫 번째 리뷰를 남겨주세요!")
@@ -56,10 +56,9 @@ struct GameDetailReviewHScrollView: View {
                 }
                 .frame(height: 114)
                 .frame(maxWidth: .infinity)
-                .padding(.trailing, 24)
             }
         }
-        .padding(.leading, 24)
+        .padding(.horizontal, 24)
     }
 }
 

--- a/Projects/App/Sources/Feature/Game/View/GameDetailView.swift
+++ b/Projects/App/Sources/Feature/Game/View/GameDetailView.swift
@@ -73,6 +73,7 @@ struct GameDetailView: View {
                 GameSimilarHScrollView(title: "비슷한 인원수의 게임", games: gameDetailViewModel.similarPlayerGames)
             }
             .background(Color.white)
+            .padding(.bottom, 32)
         }
         .onAppear {
             setGameInViewModel()
@@ -124,7 +125,7 @@ struct GameDetailView: View {
         Rectangle()
             .foregroundColor(.white)
             .frame(width: UIScreen.main.bounds.width, height: 40)
-            .clipShape(TempRoundedCorner(radius: 20, corners: [.topLeft, .topRight]))
+            .roundedCorner(20, corners: [.topLeft, .topRight])
     }
     
     private var titleView: some View {
@@ -133,19 +134,6 @@ struct GameDetailView: View {
                 .font(.subHead1B)
             ReviewRatingCellView(rating: gameDetailViewModel.game.reviewRatingAverage)
         }
-    }
-}
-
-private struct TempRoundedCorner: Shape {
-    var radius: CGFloat = .infinity
-    var corners: UIRectCorner = .allCorners
-    
-    func path(in rect: CGRect) -> Path {
-        let path = UIBezierPath(roundedRect: rect,
-                                byRoundingCorners: corners,
-                                cornerRadii: CGSize(width: radius, height: radius))
-        
-        return Path(path.cgPath)
     }
 }
 

--- a/Projects/App/Sources/Feature/Game/View/GameSimilarHScrollView.swift
+++ b/Projects/App/Sources/Feature/Game/View/GameSimilarHScrollView.swift
@@ -18,12 +18,10 @@ struct GameSimilarHScrollView: View {
             if title.contains("장르") {
                 NavigationLink(value: games.first?.gameIntroduction.genre.first) {
                     headerView(title: title, showGrid: false)
-                        .padding(.trailing, 24)
                 }
             } else if title.contains("인원수") {
                 NavigationLink(value: games.first?.gameIntroduction.maxPlayerCount) {
                     headerView(title: title, showGrid: false)
-                        .padding(.trailing, 24)
                 }
             }
             
@@ -37,8 +35,9 @@ struct GameSimilarHScrollView: View {
                     }
                 }
             }
+            .scrollIndicators(.hidden)
         }
-        .padding(.leading, 24)
+        .padding(.horizontal, 24)
     }
     
     @ViewBuilder

--- a/Projects/App/Sources/Feature/Home/View/HomeGameCardHScrollView.swift
+++ b/Projects/App/Sources/Feature/Home/View/HomeGameCardHScrollView.swift
@@ -19,7 +19,6 @@ struct HomeGameCardHScrollView: View {
                 .onTapGesture {
                     appNavigationPath.homeViewPath.append(title)
                 }
-                .padding(.trailing, 24)
             
             ScrollView(.horizontal) {
                 HStack(spacing: 16) {
@@ -30,8 +29,9 @@ struct HomeGameCardHScrollView: View {
                     }
                 }
             }
+            .scrollIndicators(.hidden)
         }
-        .padding(.leading, 24)
+        .padding(.horizontal, 24)
     }
 }
 

--- a/Projects/App/Sources/Feature/Home/View/HomeGameGenreHScrollView.swift
+++ b/Projects/App/Sources/Feature/Home/View/HomeGameGenreHScrollView.swift
@@ -16,7 +16,6 @@ struct HomeGameGenreHScrollView: View {
     var body: some View {
         VStack(spacing: 24) {
             SectionHeaderView(title: title)
-                .padding(.trailing, 24)
                 .onTapGesture {
                     appNavigationPath.homeViewPath.append(title)
                 }
@@ -30,8 +29,9 @@ struct HomeGameGenreHScrollView: View {
                     }
                 }
             }
+            .scrollIndicators(.hidden)
         }
-        .padding(.leading, 24)
+        .padding(.horizontal, 24)
         .padding(.vertical, 32)
         .background(Color.gray50)
     }

--- a/Projects/App/Sources/Feature/Home/View/HomeView.swift
+++ b/Projects/App/Sources/Feature/Home/View/HomeView.swift
@@ -11,15 +11,23 @@ import SwiftUI
 struct HomeView: View {
     @EnvironmentObject private var homeViewModel: HomeViewModel
     @EnvironmentObject private var appNavigationPath: AppNavigationPath
+    @EnvironmentObject private var loginViewModel: LoginViewModel
     @StateObject private var eventBannerViewModel = EventBannerViewModel()
     @State private var path = NavigationPath()
+    
+    private var popularGamesTitle: String {
+        if let curUser = loginViewModel.currentUser {
+            return "\(curUser.nickname)님이 좋아하실 인기게임"
+        }
+        return "인기게임"
+    }
     
     var body: some View {
         NavigationStack(path: $appNavigationPath.homeViewPath) {
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 32) {
                     EventBannerView(eventBannerViewModel: eventBannerViewModel)
-                    HomeGameGridView(title: "채영님이 좋아하실 인기게임", games: homeViewModel.popularGames)
+                    HomeGameGridView(title: popularGamesTitle, games: homeViewModel.popularGames)
                     BorderView()
                     HomeShopListView(title: "인기 매장", shops: homeViewModel.popularShops)
                     BorderView()
@@ -62,6 +70,18 @@ struct HomeView: View {
             .task {
                 await homeViewModel.fetchData()
                 await eventBannerViewModel.fetchData()
+            }
+            .overlay {
+                if homeViewModel.isLoading {
+                    Color.white.opacity(0.9)
+                                .edgesIgnoringSafeArea(.all)
+                                .onTapGesture { }
+                    
+                    ProgressView()
+                        .tint(.gray400)
+                        .offset(y: 0)
+                        .frame(width: 200, height: 200)
+                }
             }
         }
     }

--- a/Projects/App/Sources/Feature/Home/ViewModel/HomeViewModel.swift
+++ b/Projects/App/Sources/Feature/Home/ViewModel/HomeViewModel.swift
@@ -14,6 +14,7 @@ final class HomeViewModel: ObservableObject {
     @Published var newGames: [Game] = []
     @Published var newShops: [Shop] = []
     @Published var popularGenre: [GameGenre] = []
+    @Published var isLoading: Bool = false
  
     private let firebaseManager = FirebaseManager.shared
     
@@ -30,6 +31,7 @@ final class HomeViewModel: ObservableObject {
     
     @MainActor
     func fetchData() async {
+        isLoading = true
         popularGames.removeAll()
         popularShops.removeAll()
         newGames.removeAll()
@@ -48,6 +50,7 @@ final class HomeViewModel: ObservableObject {
         } catch {
             print("Error fetching HomeviewModel : \(error.localizedDescription)")
         }
+        isLoading = false
     }
     
     func getPopularGenre() -> [GameGenre] {


### PR DESCRIPTION
 변경점 #116 

# 변경사항

## 홈
- 심플한 로딩화면 구현
- 신규게임과 종류별 Best 게임 스크롤 인디케이터 숨기기
- 배너 아래부분 라운드 처리
- 인기게임 타이틀 앞에 로그인 한 경우 유저닉네임 출력

## 게임
- 상세 설명 폰트 수정
- 리뷰와 비슷한 게임 리스트 스크롤 인디케이터 숨기기
- 리뷰 작성 후 토스트메세지 패딩 추가
- 게임디테일 가장 하단에 여백 추가
- 찜하기 상태에서 찜하기 취소가 안되는 상황 수정

# To Reviewer
- 이벤트 배너의 제대로된 데이터는 추후 입력하기로 했습니다.