### PR TITLE
GameDetailView 평점과 리뷰 개수 바로 갱신되도록 수정, 이벤트배너에 적합한 사이트 정보 입력

### DIFF
--- a/Projects/App/Sources/Feature/Game/View/GameDetailView.swift
+++ b/Projects/App/Sources/Feature/Game/View/GameDetailView.swift
@@ -24,7 +24,7 @@ struct GameDetailView: View {
             GeometryReader { geometry in
                 let offset = geometry.frame(in: .global).minY
                 setOffset(offset: offset)
-                if let url = URL(string: game.gameImage) {
+                if let url = URL(string: gameDetailViewModel.game.gameImage) {
                     KFImage(url)
                         .resizable()
                         .overlay {
@@ -49,7 +49,7 @@ struct GameDetailView: View {
                 titleView
                     .padding(.horizontal, 24)
                 
-                ItemButtonSetView(type: .game, isShowingToast: $isShowingToast, game: game)
+                ItemButtonSetView(type: .game, isShowingToast: $isShowingToast, game: gameDetailViewModel.game)
                     .frame(maxWidth: .infinity)
                     .padding(.horizontal, 24)
                     .padding(.bottom, -32)
@@ -57,7 +57,7 @@ struct GameDetailView: View {
                 BorderView()
                 
                 /// 게임 상세 정보
-                GameDetailInfoView(game: game)
+                GameDetailInfoView(game: gameDetailViewModel.game)
                 
                 BorderView()
                 
@@ -74,10 +74,9 @@ struct GameDetailView: View {
             }
             .background(Color.white)
         }
-        .onAppear {
-            setGameInViewModel()
-        }
         .task {
+            setLikeState()
+            await gameDetailViewModel.fetchGameInfo(id: game.id)
             await gameDetailViewModel.fetchReviewData()
             await gameDetailViewModel.fetchSimilarGameData()
         }
@@ -106,8 +105,7 @@ struct GameDetailView: View {
             }
     }
     
-    private func setGameInViewModel() {
-        gameDetailViewModel.game = game
+    private func setLikeState() {
         if let curUser = loginViewModel.currentUser, let likeGameArray = curUser.likeGameId {
             isHeartButton = likeGameArray.contains { $0 == game.id }
         }

--- a/Projects/App/Sources/Feature/Game/ViewModel/GameDetailViewModel.swift
+++ b/Projects/App/Sources/Feature/Game/ViewModel/GameDetailViewModel.swift
@@ -85,10 +85,10 @@ final class GameDetailViewModel: ObservableObject {
     
     /// review 작성 후 게임 모델 내 리뷰 관련 데이터 업데이트된 내용 화면에 다시 출력하기 위해 사용
     @MainActor
-    func fetchGameInfo() async {
+    func fetchGameInfo(id: String) async {
         do {
             if let data: Game = try await firebaseManager
-                .fetchOneData(collectionName: AppConstants.CollectionName.games, byId: game.id) {
+                .fetchOneData(collectionName: AppConstants.CollectionName.games, byId: id) {
                 
                 game = data
             }


### PR DESCRIPTION
변경점 #120 

# 변경사항

## GameDetail
- 해당 뷰에 진입할 때마다 fetch 하도록 변경했습니다.

## EventBanner
- 회의에서 정한대로 사이트 링크 연결했고, 이미지는 해당 사이트 이름과 유사한 게임 이미지를 선택했습니다.

# To Reviewer
- 리뷰에서 사진을 넣고 작성하는 경우 평점과 리뷰 개수는 갱신되지만 리뷰 자체는 보이지 않는 현상이 있습니다. 추측으로는 WriteReviewView 에서 사진업로드가 완료되지 않은 상태에서 dismiss 되어 review 데이터 다시 fetch 할 때 해당 리뷰가 파이어스토어에 없어서 나타나는 듯 합니다. 리뷰 작성 시 사진까지 다 업로드되고 dismiss 하면 될 것 같은데, 방법을 찾는 중입니다.
  - @parkinghun 님께서 WriteReviewView 에서 사진과 함께 작성완료 시 사진파일 업로드 완료 후 dismiss() 해 주시기로 하셨습니다.